### PR TITLE
enhancement: Helm Charts Created

### DIFF
--- a/helm/InquireDocs/Chart.yaml
+++ b/helm/InquireDocs/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: InquireDocs
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/helm/InquireDocs/templates/_helpers.tpl
+++ b/helm/InquireDocs/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "InquireDocs.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "InquireDocs.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "InquireDocs.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "InquireDocs.labels" -}}
+helm.sh/chart: {{ include "InquireDocs.chart" . }}
+{{ include "InquireDocs.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "InquireDocs.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "InquireDocs.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "InquireDocs.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "InquireDocs.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/helm/InquireDocs/templates/deployment.yaml
+++ b/helm/InquireDocs/templates/deployment.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.deployment_name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Values.deployment_name }}
+spec:
+  replicas: {{ .Values.replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.deployment_name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.deployment_name }}
+    spec:
+      containers:
+      - name: {{ .Values.container.name }}
+        image: "{{ .Values.image.name }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.container.image_pull_policy }}
+        ports:
+        - containerPort: {{ .Values.container.port }}

--- a/helm/InquireDocs/templates/ingress.yaml
+++ b/helm/InquireDocs/templates/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: {{ .Values.cluster_issuer_name }}
+    kubernetes.io/ingress.class: nginx
+  name: {{ .Values.ingress_name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  rules:
+  - host: {{ .Values.host_name }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ .Values.service_name }}
+            port:
+              number: {{ .Values.container.port }}
+        path: /
+        pathType: Prefix
+  tls:
+  - hosts:
+    - {{ .Values.host_name }}
+    secretName: {{ .Values.certificate_secret_name }}

--- a/helm/InquireDocs/templates/service.yaml
+++ b/helm/InquireDocs/templates/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.service_name }}
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: {{ .Values.deployment_name }}
+  ports:
+    - port: {{ .Values.container.port }}

--- a/helm/InquireDocs/values.yaml
+++ b/helm/InquireDocs/values.yaml
@@ -1,0 +1,26 @@
+## Common Values
+namespace: {}
+
+
+## Deployment Values
+deployment_name: {}
+replicas: {}
+
+image: 
+  name: {}
+  tag: {}
+
+container:
+  name: {}
+  port: {}
+  image_pull_policy: {}
+
+## Service Values
+service_name: {}
+
+
+## Ingress Values
+ingress_name: {}
+cluster_issuer_name: {}
+host_name: {}
+certificate_secret_name: {}


### PR DESCRIPTION
## About this PR
This PR will add Helm Charts for the application. Deployment, Service, and Ingress manifests are created. The values.yaml file contains all the values for the manifests. NOTES.txt I have left empty because I feel maintainers can describe or change any stuff as required and this will be much more convenient to the end user. 
In the Ingress, I have configured it to use with SSL certificates, and the required values can be filled during the deployment; otherwise, it can be ignored, and the service can be exposed in the classic way. 
## Note
1. Deployment, Service, and Ingress manifests are created.
2. values.yaml file have four sections: Common Values, Deployment Values, Service Values, and Ingress Values and it's value can be filled during deployment.
3. Notes.txt is fully customizable.
4. Not used the Charts folder as there are no dependencies for this helm deployment.
## Feature Added
Solved:  InquireDocs/InquireDocs-Helm-Chart#1 